### PR TITLE
Add support for exactness and radix hashtags

### DIFF
--- a/README
+++ b/README
@@ -12,11 +12,13 @@ automatically coerse between fixnums, bignums, rationals, floating
 point, and complex numbers.
 
 
-Contributors: I want to thank the following people:
+Contributors: The following people have contributed to this library
 
     Zhe Zhang
     Ethan Cecchetti
     Ugur Cekmez
+    Dan King
+    Emmanuel Schanzer
 
 
 Other sources:

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2443,9 +2443,9 @@ if (typeof(exports) !== 'undefined') {
     function flonumRegexp(digits) {
 	var decimalNumOnRight = "(["+digits+"]*)\\.(["+digits+"]+)"
 	var decimalNumOnLeft = "(["+digits+"]+)\\.(["+digits+"]*)"
-	return new RegExp("^(?:([+-]?)" +
+	return new RegExp("^(?:([+-]?)(" +
                           decimalNumOnRight+"|"+decimalNumOnLeft +
-                          ")$");
+                          "))$");
     }
     function scientificPattern(digits, exp_mark) {
 	var noDecimal = "["+digits+"]+"
@@ -2572,8 +2572,8 @@ if (typeof(exports) !== 'undefined') {
 
 	var fMatch = x.match(flonumRegexp(digitsForRadix(radix)))
 	if (fMatch) {
-	    var integralPart = fMatch[2] !== undefined ? fMatch[2] : fMatch[4];
-	    var fractionalPart = fMatch[3] !== undefined ? fMatch[3] : fMatch[5];
+	    var integralPart = fMatch[3] !== undefined ? fMatch[3] : fMatch[5];
+	    var fractionalPart = fMatch[4] !== undefined ? fMatch[4] : fMatch[6];
 	    return parseFloat( fMatch[1]
                              , integralPart
                              , fractionalPart

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2453,7 +2453,7 @@ if (typeof(exports) !== 'undefined') {
 	var decimalNumOnLeft = "["+digits+"]+\\.["+digits+"]*"
 	return new RegExp("^(?:([+-]?" +
 			  "(?:"+noDecimal+"|"+decimalNumOnRight+"|"+decimalNumOnLeft+")" +
-			  ")["+exp_mark+"](\\+?["+digits+"]+))$");
+			  ")["+exp_mark+"]([+-]?["+digits+"]+))$");
     }
 
     function digitsForRadix(radix) {

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2534,10 +2534,7 @@ if (typeof(exports) !== 'undefined') {
 	} else if (mustBeANumberp) {
       if(x.length===0) throwRuntimeError("no digits");
 //	    else
-            throwRuntimeError("cannot parse " + x + " as an " +
-                              (exactp ? "exact" : "inexact") +
-                              " base " + radix + " number",
-                              this);
+            throwRuntimeError("bad number: " + x, this);
 	} else {
 	    return false;
 	}

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2584,7 +2584,7 @@ if (typeof(exports) !== 'undefined') {
                                 exactp ? parseExactInt(integralPart, radix) :
                                          parseInt(integralPart, radix)
 
-	var fractionalNumerator = exactp ? parseExactInt(integralPart, radix) :
+	var fractionalNumerator = exactp ? parseExactInt(fractionalPart, radix) :
                                            parseInt(fractionalPart, radix)
 	/* unfortunately, for these next two calculations, `expt` and `divide` */
 	/* will promote to Bignum and Rational, respectively, but we only want */

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2441,11 +2441,15 @@ if (typeof(exports) !== 'undefined') {
 	}
 
 	var numberString = hMatch ? hMatch[2] : x
+	// if the string begins with a hash modifier, then it must parse as a
+	// number, an invalid parse is an error, not false. False is returned
+	// when the item could potentially have been read as a symbol.
+	var mustBeANumberp = hMatch ? true : false
 
-	return fromStringRaw(numberString, radix, exactp)
+	return fromStringRaw(numberString, radix, exactp, mustBeANumberp)
     };
 
-    function fromStringRaw(x, radix, exactp) {
+    function fromStringRaw(x, radix, exactp, mustBeANumberp) {
 	// exactp is currently unused
 	var cMatch = x.match(complexRegexp(digitsForRadix(radix)));
 	if (cMatch) {
@@ -2459,10 +2463,10 @@ if (typeof(exports) !== 'undefined') {
 							      ));
 	}
 
-        return fromStringRawNoComplex(x, radix, exactp)
+        return fromStringRawNoComplex(x, radix, exactp, mustBeANumberp)
     }
 
-    function fromStringRawNoComplex(x, radix, exactp) {
+    function fromStringRawNoComplex(x, radix, exactp, mustBeANumberp) {
 	// exactp is currently unused
 	var aMatch = x.match(rationalRegexp(digitsForRadix(radix)));
 	if (aMatch) {
@@ -2503,11 +2507,13 @@ if (typeof(exports) !== 'undefined') {
 	    } else {
 		return n;
 	    }
-	} else {
+	} else if (mustBeANumberp) {
 	    throwRuntimeError("fromString: cannot parse " + x + " as an " +
                               (exactp ? "exact" : "inexact") +
                               " base " + radix + " number",
                               this);
+	} else {
+	    return false;
 	}
     };
 

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2426,6 +2426,7 @@ if (typeof(exports) !== 'undefined') {
 		var f = exactFlag[1].charAt(1)
 		exactp = f === 'e' ? true :
 			 f === 'i' ? false :
+			 // this case is unreachable
 			 throwRuntimeError("fromString: invalid exactness flag", this, r)
 	    }
 	    if (radixFlag) {
@@ -2434,6 +2435,7 @@ if (typeof(exports) !== 'undefined') {
 			f === 'o' ? 8 :
 			f === 'd' ? 10 :
 			f === 'x' ? 16 :
+			 // this case is unreachable
 			throwRuntimeError("fromString: invalid radix flag", this, r)
 	    }
 	}

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2408,7 +2408,7 @@ if (typeof(exports) !== 'undefined') {
                           ")$");
     }
     function scientificPattern(digits, exp_mark) {
-	var noDecimal = "["+digits+"]"
+	var noDecimal = "["+digits+"]+"
 	var decimalNumOnRight = "["+digits+"]*\\.["+digits+"]+"
 	var decimalNumOnLeft = "["+digits+"]+\\.["+digits+"]*"
 	return new RegExp("^(?:([+-]?" +

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2570,9 +2570,8 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else if (mustBeANumberp) {
-      if(x.length===0) throwRuntimeError("no digits");
-//	    else
-            throwRuntimeError("bad number: " + x, this);
+	    if(x.length===0) throwRuntimeError("no digits");
+	    throwRuntimeError("bad number: " + x, this);
 	} else {
 	    return false;
 	}

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -3930,6 +3930,9 @@ if (typeof(exports) !== 'undefined') {
     })();
 
 
+    // sqrt: -> scheme-number
+    // http://en.wikipedia.org/wiki/Newton's_method#Square_root_of_a_number
+    // Produce the square root.
     (function() {	
 	// Get an approximation using integerSqrt, and then start another
 	// Newton-Ralphson search if necessary.
@@ -3953,14 +3956,6 @@ if (typeof(exports) !== 'undefined') {
 	};
     })();
 
-
-
-
-    
-    // sqrt: -> scheme-number
-    // http://en.wikipedia.org/wiki/Newton's_method#Square_root_of_a_number
-    // Produce the square root.
-
     // floor: -> scheme-number
     // Produce the floor.
     BigInteger.prototype.floor = function() {
@@ -3973,27 +3968,57 @@ if (typeof(exports) !== 'undefined') {
         return this;
     }
 
+
+    // Until we have a feature-complete Big Number implementation, we'll
+    // convert BigInteger objects into FloatPoint objects and perform
+    // unsupported operations there.
+    function temporaryAccuracyLosingWorkAroundForBigNums(function_name) {
+      return function () { return this.toInexact()[function_name]() }
+    }
+
     // conjugate: -> scheme-number
     // Produce the conjugate.
+    BigInteger.prototype.conjugate = temporaryAccuracyLosingWorkAroundForBigNums("conjugate");
 
     // magnitude: -> scheme-number
     // Produce the magnitude.
+    BigInteger.prototype.magnitude = temporaryAccuracyLosingWorkAroundForBigNums("magnitude");
 
     // log: -> scheme-number
     // Produce the log.
+    BigInteger.prototype.log = temporaryAccuracyLosingWorkAroundForBigNums("log");
 
     // angle: -> scheme-number
     // Produce the angle.
+    BigInteger.prototype.angle = temporaryAccuracyLosingWorkAroundForBigNums("angle");
 
     // atan: -> scheme-number
     // Produce the arc tangent.
+    BigInteger.prototype.atan = temporaryAccuracyLosingWorkAroundForBigNums("atan");
+
+    // acos: -> scheme-number
+    // Produce the arc cosine.
+    BigInteger.prototype.acos = temporaryAccuracyLosingWorkAroundForBigNums("acos");
+
+    // asin: -> scheme-number
+    // Produce the arc sine.
+    BigInteger.prototype.asin = temporaryAccuracyLosingWorkAroundForBigNums("asin");
+
+    // tan: -> scheme-number
+    // Produce the tangent.
+    BigInteger.prototype.tan = temporaryAccuracyLosingWorkAroundForBigNums("tan");
 
     // cos: -> scheme-number
     // Produce the cosine.
+    BigInteger.prototype.cos = temporaryAccuracyLosingWorkAroundForBigNums("cos");
 
     // sin: -> scheme-number
     // Produce the sine.
+    BigInteger.prototype.sin = temporaryAccuracyLosingWorkAroundForBigNums("sin");
 
+    // exp: -> scheme-number
+    // Produce e raised to the given power.
+    BigInteger.prototype.exp = temporaryAccuracyLosingWorkAroundForBigNums("exp");
 
     // expt: scheme-number -> scheme-number
     // Produce the power to the input.
@@ -4002,15 +4027,6 @@ if (typeof(exports) !== 'undefined') {
     };
 
 
-
-    // exp: -> scheme-number
-    // Produce e raised to the given power.
-
-    // acos: -> scheme-number
-    // Produce the arc cosine.
-
-    // asin: -> scheme-number
-    // Produce the arc sine.
 
     BigInteger.prototype.imaginaryPart = function() {
 	    return 0;
@@ -4021,6 +4037,9 @@ if (typeof(exports) !== 'undefined') {
 
     // round: -> scheme-number
     // Round to the nearest integer.
+    BigInteger.prototype.round = function() {
+	    return this;
+    }
 
 
 

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -1581,7 +1581,11 @@ if (typeof(exports) !== 'undefined') {
 
 	if (d === undefined) { d = 1; }
 
-	if (_integerLessThan(d, 0)) {
+	if (_integerIsZero(d)) {
+	    throwRuntimeError("division by zero: "+n+"/"+d);
+	}
+
+  if (_integerLessThan(d, 0)) {
 	    n = negate(n);
 	    d = negate(d);
 	}
@@ -2427,7 +2431,7 @@ if (typeof(exports) !== 'undefined') {
 		exactp = f === 'e' ? true :
 			 f === 'i' ? false :
 			 // this case is unreachable
-			 throwRuntimeError("fromString: invalid exactness flag", this, r)
+			 throwRuntimeError("invalid exactness flag", this, r)
 	    }
 	    if (radixFlag) {
 		var f = radixFlag[1].charAt(1)
@@ -2436,7 +2440,7 @@ if (typeof(exports) !== 'undefined') {
 			f === 'd' ? 10 :
 			f === 'x' ? 16 :
 			 // this case is unreachable
-			throwRuntimeError("fromString: invalid radix flag", this, r)
+			throwRuntimeError("invalid radix flag", this, r)
 	    }
 	}
 
@@ -2508,7 +2512,7 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else if (mustBeANumberp) {
-	    throwRuntimeError("fromString: cannot parse " + x + " as an " +
+	    throwRuntimeError("cannot parse " + x + " as an " +
                               (exactp ? "exact" : "inexact") +
                               " base " + radix + " number",
                               this);

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2386,7 +2386,7 @@ if (typeof(exports) !== 'undefined') {
 
 
 
-    var hashModifiersRegexp = new RegExp("^(#[ei]#[bodx]|#[bodx]#[ei]|#[bodxei])?(.*)$")
+    var hashModifiersRegexp = new RegExp("^(#[ei]#[bodx]|#[bodx]#[ei]|#[bodxei])(.*)$")
     function rationalRegexp(digits) { return new RegExp("^([+-]?["+digits+"]+)/(["+digits+"]+)$"); }
     function complexRegexp(digits) { return new RegExp("^([+-]?["+digits+"\\w/\\.]*)([+-])(["+digits+"\\w/\\.]*)i$"); }
     function digitRegexp(digits) { return new RegExp("^[+-]?["+digits+"]+$"); }
@@ -2416,7 +2416,7 @@ if (typeof(exports) !== 'undefined') {
 	var exactp = false
 
 	var hMatch = x.match(hashModifiersRegexp)
-	if (hMatch[1]) {
+	if (hMatch) {
 	    var modifierString = hMatch[1];
 
 	    var exactFlag = modifierString.match(new RegExp("(#[ei])"))

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2512,7 +2512,7 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else if (mustBeANumberp) {
-//      if(x.length===0) throwRuntimeError("no digits");
+      if(x.length===0) throwRuntimeError("no digits");
 //	    else
             throwRuntimeError("cannot parse " + x + " as an " +
                               (exactp ? "exact" : "inexact") +

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -3116,7 +3116,7 @@ if (typeof(exports) !== 'undefined') {
     BigInteger.prototype.divRemTo = bnpDivRemTo;
     BigInteger.prototype.invDigit = bnpInvDigit;
     BigInteger.prototype.isEven = bnpIsEven;
-    BigInteger.prototype.exp = bnpExp;
+    BigInteger.prototype.bnpExp = bnpExp;
 
     // public
     BigInteger.prototype.toString = bnToString;
@@ -3467,7 +3467,7 @@ if (typeof(exports) !== 'undefined') {
     NullExp.prototype.sqrTo = nSqrTo;
 
     // (public) this^e
-    function bnPow(e) { return this.exp(e,new NullExp()); }
+    function bnPow(e) { return this.bnpExp(e,new NullExp()); }
 
     // (protected) r = lower n words of "this * a", a.t <= n
     // "this" should be the larger one if appropriate.
@@ -3770,6 +3770,7 @@ if (typeof(exports) !== 'undefined') {
     BigInteger.prototype.modPow = bnModPow;
     BigInteger.prototype.modInverse = bnModInverse;
     BigInteger.prototype.pow = bnPow;
+    BigInteger.prototype.expt = bnPow;
     BigInteger.prototype.gcd = bnGCD;
     BigInteger.prototype.isProbablePrime = bnIsProbablePrime;
 
@@ -4045,12 +4046,6 @@ if (typeof(exports) !== 'undefined') {
     // exp: -> scheme-number
     // Produce e raised to the given power.
     BigInteger.prototype.exp = temporaryAccuracyLosingWorkAroundForBigNums("exp");
-
-    // expt: scheme-number -> scheme-number
-    // Produce the power to the input.
-    BigInteger.prototype.expt = temporaryAccuracyLosingWorkAroundForBigNums("expt");
-
-
 
     BigInteger.prototype.imaginaryPart = function() {
 	    return 0;

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2584,8 +2584,9 @@ if (typeof(exports) !== 'undefined') {
                                 exactp ? parseExactInt(integralPart, radix) :
                                          parseInt(integralPart, radix)
 
-	var fractionalNumerator = exactp ? parseExactInt(fractionalPart, radix) :
-                                           parseInt(fractionalPart, radix)
+	var fractionalNumerator = fractionalPart === "" ? 0 :
+				  exactp ? parseExactInt(fractionalPart, radix) :
+					   parseInt(fractionalPart, radix)
 	/* unfortunately, for these next two calculations, `expt` and `divide` */
 	/* will promote to Bignum and Rational, respectively, but we only want */
 	/* these if we're parsing in exact mode */

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2471,9 +2471,9 @@ if (typeof(exports) !== 'undefined') {
     }
 
     // fromString: string -> (scheme-number | false)
-    var fromString = function(x) {
+    var fromString = function(x, exactp) {
 	var radix = 10
-	var exactp = false;
+	var exactp = typeof exactp !== 'undefined' ? exactp : false;
 
 	var hMatch = x.toLowerCase().match(hashModifiersRegexp)
 	if (hMatch) {

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2529,8 +2529,9 @@ if (typeof(exports) !== 'undefined') {
                                 parseInt(integralPart, radix)
 
 	var fractionalNumerator = parseInt(fractionalPart, radix)
-        var fractionalDenominator = Math.pow(radix, fractionalPart.length)
-	var fractionalPartValue = fractionalNumerator / fractionalDenominator
+	var fractionalDenominator = Math.pow(radix, fractionalPart.length)
+	var fractionalPartValue = fractionalPart === "" ? 0 :
+				  fractionalNumerator / fractionalDenominator
 
 	return FloatPoint.makeInstance(sign * (integralPartValue + fractionalPartValue));
     }

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -90,7 +90,7 @@ if (typeof(exports) !== 'undefined') {
     };
 
     var expandExponent = function(s) {
-	var match = s.match(scientificPattern), mantissaChunks, exponent;
+	var match = s.match(scientificPattern(digitsForRadix(10), expMarkForRadix(10))), mantissaChunks, exponent;
 	if (match) {
 	    mantissaChunks = match[1].match(/^([^.]*)(.*)$/);
 	    exponent = Number(match[2]);

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2473,9 +2473,7 @@ if (typeof(exports) !== 'undefined') {
     // fromString: string -> (scheme-number | false)
     var fromString = function(x) {
 	var radix = 10
-	// not used currently, because parsing exact non-decimal stirngs is
-	// unimplemented
-	var exactp = false
+	var exactp = true
 
 	var hMatch = x.toLowerCase().match(hashModifiersRegexp)
 	if (hMatch) {
@@ -2512,7 +2510,6 @@ if (typeof(exports) !== 'undefined') {
     };
 
     function fromStringRaw(x, radix, exactp, mustBeANumberp) {
-	// exactp is currently unused
 	var cMatch = matchComplexRegexp(radix, x);
 	if (cMatch) {
 	  return Complex.makeInstance( fromStringRawNoComplex( cMatch[1] || "0"
@@ -2531,7 +2528,6 @@ if (typeof(exports) !== 'undefined') {
     }
 
     function fromStringRawNoComplex(x, radix, exactp, mustBeANumberp) {
-	// exactp is currently unused
 	var aMatch = x.match(rationalRegexp(digitsForRadix(radix)));
 	if (aMatch) {
 	    return Rational.makeInstance(fromStringRawNoComplex(aMatch[1], radix, exactp),
@@ -2561,7 +2557,7 @@ if (typeof(exports) !== 'undefined') {
 					      ))
 	if (sMatch) {
 	    var coefficient = fromStringRawNoComplex(sMatch[1], radix, exactp)
-	    var exponent = parseInt(sMatch[2], radix, exactp)
+	    var exponent = fromStringRawNoComplex(sMatch[2], radix, exactp)
 	    return FloatPoint.makeInstance(coefficient * Math.pow(radix, exponent));
 	}
 

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2419,9 +2419,9 @@ if (typeof(exports) !== 'undefined') {
 	// unimplemented
 	var exactp = false
 
-	var hMatch = x.match(hashModifiersRegexp)
+	var hMatch = x.toLowerCase().match(hashModifiersRegexp)
 	if (hMatch) {
-	    var modifierString = hMatch[1];
+	    var modifierString = hMatch[1].toLowerCase();
 
 	    var exactFlag = modifierString.match(new RegExp("(#[ei])"))
 	    var radixFlag = modifierString.match(new RegExp("(#[bodx])"))
@@ -2429,16 +2429,16 @@ if (typeof(exports) !== 'undefined') {
 	    if (exactFlag) {
 		var f = exactFlag[1].charAt(1)
 		exactp = f === 'e' ? true :
-			 f === 'i' ? false :
+             f === 'i' ? false :
 			 // this case is unreachable
 			 throwRuntimeError("invalid exactness flag", this, r)
 	    }
 	    if (radixFlag) {
 		var f = radixFlag[1].charAt(1)
 		radix = f === 'b' ? 2 :
-			f === 'o' ? 8 :
-			f === 'd' ? 10 :
-			f === 'x' ? 16 :
+            f === 'o' ? 8 :
+            f === 'd' ? 10 :
+            f === 'x' ? 16 :
 			 // this case is unreachable
 			throwRuntimeError("invalid radix flag", this, r)
 	    }
@@ -2512,8 +2512,9 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else if (mustBeANumberp) {
-      if(x.length===0) throwRuntimeError("no digits");
-	    else throwRuntimeError("cannot parse " + x + " as an " +
+//      if(x.length===0) throwRuntimeError("no digits");
+//	    else
+            throwRuntimeError("cannot parse " + x + " as an " +
                               (exactp ? "exact" : "inexact") +
                               " base " + radix + " number",
                               this);

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2502,7 +2502,10 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else {
-	    return false;
+	    throwRuntimeError("fromString: cannot parse " + x + " as an " +
+                              (exactp ? "exact" : "inexact") +
+                              " base " + radix + " number",
+                              this);
 	}
     };
 

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2566,6 +2566,8 @@ if (typeof(exports) !== 'undefined') {
 	    var n = parseInt(x, radix);
 	    if (isOverflow(n)) {
 		return makeBignum(x);
+	    } else if (!exactp) {
+		return FloatPoint.makeInstance(n);
 	    } else {
 		return n;
 	    }

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2470,10 +2470,29 @@ if (typeof(exports) !== 'undefined') {
 	       throwRuntimeError("expMarkForRadix: invalid radix", this, radix)
     }
 
-    // fromString: string -> (scheme-number | false)
-    var fromString = function(x, exactp) {
+    function Exactness(i) {
+      this.defaultp = function () { return i == 0; }
+      this.exactp = function () { return i == 1; }
+      this.inexactp = function () { return i == 2; }
+    }
+
+    Exactness.def = new Exactness(0);
+    Exactness.on = new Exactness(1);
+    Exactness.off = new Exactness(2);
+
+    Exactness.prototype.intAsExactp = function () { return this.defaultp() || this.exactp(); };
+    Exactness.prototype.floatAsInexactp = function () { return this.defaultp() || this.inexactp(); };
+
+
+    // fromString: string boolean -> (scheme-number | false)
+    var fromString = function(x, exactness) {
 	var radix = 10
-	var exactp = typeof exactp !== 'undefined' ? exactp : false;
+	var exactness = typeof exactness === 'undefined' ? Exactness.def :
+			exactness === true               ? Exactness.on :
+			exactness === false              ? Exactness.off :
+	   /* else */  throwRuntimeError( "exactness must be true or false"
+                                        , this
+                                        , r) ;
 
 	var hMatch = x.toLowerCase().match(hashModifiersRegexp)
 	if (hMatch) {
@@ -2484,8 +2503,8 @@ if (typeof(exports) !== 'undefined') {
 
 	    if (exactFlag) {
 		var f = exactFlag[1].charAt(1)
-		exactp = f === 'e' ? true :
-             f === 'i' ? false :
+		exactness = f === 'e' ? Exactness.on :
+			    f === 'i' ? Exactness.off :
 			 // this case is unreachable
 			 throwRuntimeError("invalid exactness flag", this, r)
 	    }
@@ -2506,32 +2525,38 @@ if (typeof(exports) !== 'undefined') {
 	// when the item could potentially have been read as a symbol.
 	var mustBeANumberp = hMatch ? true : false
 
-	return fromStringRaw(numberString, radix, exactp, mustBeANumberp)
+	return fromStringRaw(numberString, radix, exactness, mustBeANumberp)
     };
 
-    function fromStringRaw(x, radix, exactp, mustBeANumberp) {
+    function fromStringRaw(x, radix, exactness, mustBeANumberp) {
 	var cMatch = matchComplexRegexp(radix, x);
 	if (cMatch) {
 	  return Complex.makeInstance( fromStringRawNoComplex( cMatch[1] || "0"
 							     , radix
-							     , exactp
+							     , exactness
 							     )
 				     , fromStringRawNoComplex( cMatch[2] === "+" ? "1"  :
 							       cMatch[2] === "-" ? "-1" :
 							       cMatch[2]
 							     , radix
-							     , exactp
+							     , exactness
 							     ));
 	}
 
-        return fromStringRawNoComplex(x, radix, exactp, mustBeANumberp)
+        return fromStringRawNoComplex(x, radix, exactness, mustBeANumberp)
     }
 
-    function fromStringRawNoComplex(x, radix, exactp, mustBeANumberp) {
+    function fromStringRawNoComplex(x, radix, exactness, mustBeANumberp) {
 	var aMatch = x.match(rationalRegexp(digitsForRadix(radix)));
 	if (aMatch) {
-	    return Rational.makeInstance(fromStringRawNoComplex(aMatch[1], radix, exactp),
-					 fromStringRawNoComplex(aMatch[2], radix, exactp));
+	    return Rational.makeInstance( fromStringRawNoComplex( aMatch[1]
+                                                                , radix
+                                                                , exactness
+                                                                )
+                                        , fromStringRawNoComplex( aMatch[2]
+                                                                , radix
+                                                                , exactness
+                                                                ));
 	}
 
 	// Floating point tests
@@ -2549,15 +2574,20 @@ if (typeof(exports) !== 'undefined') {
 	if (fMatch) {
 	    var integralPart = fMatch[2] !== undefined ? fMatch[2] : fMatch[4];
 	    var fractionalPart = fMatch[3] !== undefined ? fMatch[3] : fMatch[5];
-	    return parseFloat(fMatch[1], integralPart, fractionalPart, radix, exactp)
+	    return parseFloat( fMatch[1]
+                             , integralPart
+                             , fractionalPart
+                             , radix
+                             , exactness
+                             )
 	}
 
 	var sMatch = x.match(scientificPattern( digitsForRadix(radix)
 					      , expMarkForRadix(radix)
 					      ))
 	if (sMatch) {
-	    var coefficient = fromStringRawNoComplex(sMatch[1], radix, exactp)
-	    var exponent = fromStringRawNoComplex(sMatch[2], radix, exactp)
+	    var coefficient = fromStringRawNoComplex(sMatch[1], radix, exactness)
+	    var exponent = fromStringRawNoComplex(sMatch[2], radix, exactness)
 	    return multiply(coefficient, expt(radix, exponent));
 	}
 
@@ -2566,8 +2596,10 @@ if (typeof(exports) !== 'undefined') {
 	    var n = parseInt(x, radix);
 	    if (isOverflow(n)) {
 		return makeBignum(x);
-	    } else {
+	    } else if (exactness.intAsExactp()) {
 		return n;
+	    } else {
+		return FloatPoint.makeInstance(n)
 	    }
 	} else if (mustBeANumberp) {
 	    if(x.length===0) throwRuntimeError("no digits");
@@ -2577,30 +2609,35 @@ if (typeof(exports) !== 'undefined') {
 	}
     };
 
-    function parseFloat(sign, integralPart, fractionalPart, radix, exactp) {
+    function parseFloat(sign, integralPart, fractionalPart, radix, exactness) {
 	var sign = (sign == "-" ? -1 : 1);
 	var integralPartValue = integralPart === ""  ? 0  :
-                                exactp ? parseExactInt(integralPart, radix) :
-                                         parseInt(integralPart, radix)
+				exactness.intAsExactp() ? parseExactInt(integralPart, radix) :
+							  parseInt(integralPart, radix)
 
 	var fractionalNumerator = fractionalPart === "" ? 0 :
-				  exactp ? parseExactInt(fractionalPart, radix) :
-					   parseInt(fractionalPart, radix)
+				  exactness.intAsExactp() ? parseExactInt(fractionalPart, radix) :
+							    parseInt(fractionalPart, radix)
 	/* unfortunately, for these next two calculations, `expt` and `divide` */
 	/* will promote to Bignum and Rational, respectively, but we only want */
 	/* these if we're parsing in exact mode */
-	var fractionalDenominator = exactp ? expt(radix, fractionalPart.length) :
-					     Math.pow(radix, fractionalPart.length)
+	var fractionalDenominator = exactness.intAsExactp() ? expt(radix, fractionalPart.length) :
+							      Math.pow(radix, fractionalPart.length)
 	var fractionalPartValue = fractionalPart === "" ? 0 :
-				  exactp ? divide(fractionalNumerator, fractionalDenominator) :
-				           fractionalNumerator / fractionalDenominator
+				  exactness.intAsExactp() ? divide(fractionalNumerator, fractionalDenominator) :
+							    fractionalNumerator / fractionalDenominator
 
-	return exactp ? multiply(sign, add(integralPartValue, fractionalPartValue)) :
-                        FloatPoint.makeInstance(sign * (integralPartValue + fractionalPartValue));
+	var forceInexact = function(o) {
+	    return typeof o === "number" ? FloatPoint.makeInstance(o) :
+					   o.toInexact();
+	}
+
+	return exactness.floatAsInexactp() ? forceInexact(multiply(sign, add( integralPartValue, fractionalPartValue))) :
+					     multiply(sign, add(integralPartValue, fractionalPartValue));
     }
 
     function parseExactInt(str, radix) {
-	return fromStringRawNoComplex(str, radix, true, true);
+	return fromStringRawNoComplex(str, radix, Exactness.on, true);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2512,7 +2512,8 @@ if (typeof(exports) !== 'undefined') {
 		return n;
 	    }
 	} else if (mustBeANumberp) {
-	    throwRuntimeError("cannot parse " + x + " as an " +
+      if(x.length===0) throwRuntimeError("no digits");
+	    else throwRuntimeError("cannot parse " + x + " as an " +
                               (exactp ? "exact" : "inexact") +
                               " base " + radix + " number",
                               this);

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -3996,7 +3996,10 @@ if (typeof(exports) !== 'undefined') {
     // convert BigInteger objects into FloatPoint objects and perform
     // unsupported operations there.
     function temporaryAccuracyLosingWorkAroundForBigNums(function_name) {
-      return function () { return this.toInexact()[function_name]() }
+      return function () {
+	var inexact = this.toInexact();
+	return inexact[function_name].apply(inexact, arguments);
+      }
     }
 
     // conjugate: -> scheme-number
@@ -4045,9 +4048,7 @@ if (typeof(exports) !== 'undefined') {
 
     // expt: scheme-number -> scheme-number
     // Produce the power to the input.
-    BigInteger.prototype.expt = function(n) {
-	return bnPow.call(this, n);
-    };
+    BigInteger.prototype.expt = temporaryAccuracyLosingWorkAroundForBigNums("expt");
 
 
 

--- a/src/js-numbers.js
+++ b/src/js-numbers.js
@@ -2394,7 +2394,7 @@ if (typeof(exports) !== 'undefined') {
     function rationalRegexp(digits) { return new RegExp("^([+-]?["+digits+"]+)/(["+digits+"]+)$"); }
     function complexRegexp(digits) { return new RegExp("^([+-]?["+digits+"\\w/\\.]*)([+-])(["+digits+"\\w/\\.]*)i$"); }
     function digitRegexp(digits) { return new RegExp("^[+-]?["+digits+"]+$"); }
-    function flonumRegexp(digits) { return new RegExp("^([+-]?["+digits+"]*)\\.(["+digits+"]*)$"); }
+    function flonumRegexp(digits) { return new RegExp("^([+-]?)(["+digits+"]*)\\.(["+digits+"]*)$"); }
     function scientificPattern(digits, exp_mark)
 	{ return new RegExp("^([+-]?["+digits+"]*\\.?["+digits+"]*)["+exp_mark+"](\\+?["+digits+"]+)$"); }
 
@@ -2491,7 +2491,7 @@ if (typeof(exports) !== 'undefined') {
 
 	var fMatch = x.match(flonumRegexp(digitsForRadix(radix)))
 	if (fMatch) {
-	    return parseFloat(fMatch[1], fMatch[2], radix)
+	    return parseFloat(fMatch[1], fMatch[2], fMatch[3], radix)
 	}
 
 	var sMatch = x.match(scientificPattern( digitsForRadix(radix)
@@ -2523,14 +2523,16 @@ if (typeof(exports) !== 'undefined') {
 	}
     };
 
-    function parseFloat(integralPart, fractionalPart, radix) {
-	var integralPartValue = parseInt(integralPart, radix)
+    function parseFloat(sign, integralPart, fractionalPart, radix) {
+	var sign = (sign == "-" ? -1 : 1);
+	var integralPartValue = integralPart === ""  ? 0  :
+                                parseInt(integralPart, radix)
 
 	var fractionalNumerator = parseInt(fractionalPart, radix)
         var fractionalDenominator = Math.pow(radix, fractionalPart.length)
 	var fractionalPartValue = fractionalNumerator / fractionalDenominator
 
-	return FloatPoint.makeInstance(integralPartValue + fractionalPartValue);
+	return FloatPoint.makeInstance(sign * (integralPartValue + fractionalPartValue));
     }
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -182,6 +182,7 @@ describe('fromString', {
  	assertEquals(makeFloat(10000000000000000.2),
  		     fromString("10000000000000000.2"));
 	assertEquals(makeFloat(0.5), fromString(".5"));
+	assertEquals(makeFloat(0.0), fromString("#i0"));
 	assertEquals(makeFloat(0.0), fromString("0."));
 	assertEquals(makeFloat(0.0), fromString("0.d1"));
 	assertEquals(makeFloat(0.0), fromString(".0d1"));
@@ -780,6 +781,11 @@ describe('isExact', {
     },
 
     'floats': function() {
+	assertTrue(isExact(fromString("#e0")));
+	assertTrue(isExact(fromString("#e0.0")));
+	assertTrue(isExact(fromString("#e0.")));
+	assertTrue(isExact(fromString("#e.0")));
+	assertFalse(isExact(fromString("#i0")));
 	assertFalse(isExact(e));
 	assertFalse(isExact(pi));
 	assertFalse(isExact(inf));

--- a/test/tests.js
+++ b/test/tests.js
@@ -758,6 +758,7 @@ describe('isExact', {
     },
 
     'rationals': function() {
+        assertTrue(isExact(fromString("#e3.2")));
 	assertTrue(isExact(makeRational(19)));
 	assertTrue(isExact(makeRational(0)));
 	assertTrue(isExact(makeRational(-1)));

--- a/test/tests.js
+++ b/test/tests.js
@@ -170,6 +170,15 @@ describe('fromString', {
  	assertEquals(makeFloat(10000000000000000.2),
  		     fromString("10000000000000000.2"));
 	assertEquals(makeFloat(0.5), fromString(".5"));
+	assertEquals(makeFloat(0.0), fromString("0."));
+	assertEquals(makeFloat(0.0), fromString("0.d1"));
+	assertEquals(makeFloat(0.0), fromString(".0d1"));
+	assertEquals(makeFloat(0.0), fromString("0.0d1"));
+	assertEquals(makeFloat(10.0), fromString("1.d1"));
+	assertEquals(makeFloat(1.0), fromString(".1d1"));
+	assertEquals(makeFloat(11.0), fromString("1.1d1"));
+	assertEquals(makeFloat(1), fromString("#d1"));
+	assertFalse(fromString("d1"));
     },
 
     'complex': function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -158,6 +158,14 @@ describe('fromString', {
 		     fromString("#e3.2"));
 	assertEquals(makeRational(5, 10),
 		     fromString("#e0.5"));
+	assertEquals(makeRational(100, 1),
+		     fromString("#e100."));
+	assertEquals(makeRational(1014, 10),
+		     fromString("#e101.4"));
+	assertEquals(makeRational(1, 10000),
+		     fromString("#e0.0001"));
+	assertEquals(makeRational(1, 10000),
+		     fromString("#e.0001"));
     },
 
     'floats': function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -169,6 +169,7 @@ describe('fromString', {
 		     fromString("1000000000000000.2"));
  	assertEquals(makeFloat(10000000000000000.2),
  		     fromString("10000000000000000.2"));
+	assertEquals(makeFloat(0.5), fromString(".5"));
     },
 
     'complex': function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -154,6 +154,10 @@ describe('fromString', {
 	assertEquals(makeRational(makeBignum("-13284973298"),
 				  makeBignum("239875239")),
 		     fromString("-13284973298/239875239"));
+	assertEquals(makeRational(32, 10),
+		     fromString("#e3.2"));
+	assertEquals(makeRational(5, 10),
+		     fromString("#e0.5"));
     },
 
     'floats': function() {


### PR DESCRIPTION
Add support for exactness, radix hashtag syntax, and parsing base 2, 8, and 16 numbers

This syntax is specified in "1.3.3 Reading Numbers" [1] of the Racket Documentation.

Although the exactness syntax is now supported, this patch doesn't force parsing as bignums. I need help writing a bignum number parser for non-decimal numbers.

I don't know how tests are supposed to be written in this project. While developing I appending the following cods snippet to the file and executed the file with node. With this patch, the project passes all the tests below.

``` racket
    function testThis(x){
      console.log(__PLTNUMBERS_TOP__.fromString(x))
      return __PLTNUMBERS_TOP__.fromString(x)
    }

    console.log(testThis("-1") == -1)
    console.log((function (actual) { return actual.n == 1 && actual.d == 2})(testThis("1/2")))
    console.log(testThis("1.0") == 1.0)
    console.log(testThis("2e5") == 200000)
    console.log(testThis("#i5") == 5)
    console.log(testThis("#e2e5") == 200000)
    console.log(testThis("#x2e5") == 741)
    console.log(testThis("#b101") == 5)
```

[1] http://www.cs.utah.edu/plt/snapshots/current/doc/reference/reader.html?q=parsing%20numbers#%28part._parse-number%29
